### PR TITLE
fix(typescript): Change module export styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ npm install --save @moqada/simple-api-client
 
 ## Usage
 
+### JavaScript
+
 ```javascript
 import SimpleAPIClient from '@moqada/simple-api-client';
 
@@ -61,6 +63,14 @@ client.getUsers({offset: 20, limit: 10}).then(({body}) => {
 }).catch(({error}) => {
   console.error(error);
 }):
+```
+
+### TypeScript
+
+A import style is different from JavaScript.
+
+```typescript
+import {SimpleAPIClient} from '@moqada/simple-api-client';
 ```
 
 ## Todo

--- a/src/SimpleAPIClient.js
+++ b/src/SimpleAPIClient.js
@@ -11,7 +11,7 @@ export type APIOption = {
 /**
  * Simple API Client
  */
-export default class SimpleAPIClient<APIResponse: Object = {error: any, response: any}> {
+export class SimpleAPIClient<APIResponse: Object = {error: any, response: any}> {
   endpoint: string;
   timeout: ?number;
 
@@ -144,3 +144,4 @@ export default class SimpleAPIClient<APIResponse: Object = {error: any, response
     return this.send('post', path, opts);
   }
 }
+export default SimpleAPIClient;

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -11,7 +11,7 @@ declare module '@moqada/simple-api-client' {
     timeout?: number;
   };
 
-  class SimpleAPIClient<APIResponse = {error: any; response: any}> {
+  export class SimpleAPIClient<APIResponse = {error: any; response: any}> {
     endpoint: string;
     timeout: number | void;
 
@@ -25,6 +25,4 @@ declare module '@moqada/simple-api-client' {
     put(path: string, opts?: APIOption): Promise<APIResponse>;
     post(path: string, opts?: APIOption): Promise<APIResponse>;
   }
-
-  export default SimpleAPIClient;
 }

--- a/typescript/test/SimpleAPIClient.spec.ts
+++ b/typescript/test/SimpleAPIClient.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable require-jsdoc */
 import * as assert from 'assert';
-import SimpleAPIClient from '@moqada/simple-api-client';
+import {SimpleAPIClient} from '@moqada/simple-api-client';
 
 const ENDPOINT = 'http://localhost';
 const HEADERS = {'X-Foo': 'xxxxx'};


### PR DESCRIPTION
BREAKING CHANGE: Module import styles changed for JavaScript and TypeScript.

JavaScript

```javascript
// before
const SimpleAPIClient = require('@moqada/simple-api-client');
const SimpleAPIClient from '@moqada/simple-api-client';

// after: changed in require style
const {SimpleAPIClient} = require('@moqada/simple-api-client');
// after: not changed in import style
const SimpleAPIClient from '@moqada/simple-api-client';
```

TypeScript

```
// before
import SimpleAPIClient from '@moqada/simple-api-client';

// after
import {SimpleAPIClient} from '@moqada/simple-api-client';
```